### PR TITLE
Support Refinement rule specific type inference

### DIFF
--- a/lib/infer.js
+++ b/lib/infer.js
@@ -3,7 +3,6 @@ import CfgBuilder from "./cfg/cfg-builder";
 import SymbolExtractor from "./semantic-model/symbol-extractor";
 import {ForwardAnalysisTypeInference} from "./type-inference/forward-analysis-type-inference";
 import {WorklistDataFlowAnalyzer} from "./data-flow-analysis/worklist-data-flow-analyzer";
-import {HindleyMilner} from "./type-inference/hindley-milner";
 
 export function infer(sourceFile, program) {
 	sourceFile.parse();
@@ -11,7 +10,7 @@ export function infer(sourceFile, program) {
 	const visitors = [createTraverseVisitorWrapper(new CfgBuilder(sourceFile.ast)), createTraverseVisitorWrapper(new SymbolExtractor(program))];
 	sourceFile.analyse(visitors);
 
-	const forwardTypeInferenceAnalysis = new ForwardAnalysisTypeInference(new HindleyMilner(program));
+	const forwardTypeInferenceAnalysis = new ForwardAnalysisTypeInference(program);
 	const typeInferenceAnalyzer = new WorklistDataFlowAnalyzer(sourceFile.ast.cfg, forwardTypeInferenceAnalysis);
 	typeInferenceAnalyzer.analyze();
 }

--- a/lib/type-inference/forward-analysis-type-inference.js
+++ b/lib/type-inference/forward-analysis-type-inference.js
@@ -1,6 +1,8 @@
 import TypeEnvironment from "./type-environment";
 import process from "process";
 import {createLabelForNode} from "../util";
+import {TypeInferenceContext} from "./type-inference-context";
+import {HindleyMilner} from "./hindley-milner";
 
 /**
  * A type inference that infers the most specific type for each position in the cfg.
@@ -8,11 +10,13 @@ import {createLabelForNode} from "../util";
  */
 export class ForwardAnalysisTypeInference {
 	/**
-	 * Creates a new forward type inference analysis that uses the passed in hindley milner instance
-	 * @param {HindleyMilner} hindleyMilner
+	 * Creates a new forward type inference analysis for the passed in program
+	 * @param {Program} program the program that is being analysed
+	 * @param {HindleyMilner} [hindleyMilner] the hindley milner algorithm instance to use
      */
-	constructor(hindleyMilner) {
-		this.hindleyMilner = hindleyMilner;
+	constructor(program, hindleyMilner=new HindleyMilner()) {
+		this._program = program;
+		this._hindleyMilner = hindleyMilner;
 	}
 
 	createEmptyLattice() {
@@ -28,7 +32,9 @@ export class ForwardAnalysisTypeInference {
 			return inTypeEnvironment;
 		}
 
-		const out = this._withTypeEnvironment(inTypeEnvironment, () => this.hindleyMilner.infer(node));
+		const context = new TypeInferenceContext(this._program, inTypeEnvironment);
+		this._hindleyMilner.infer(node, context);
+		const out = context.typeEnvironment;
 
 		const diff = out.difference(inTypeEnvironment);
 		process.stdout.write(`Diff for transfer function of node ${createLabelForNode(node)}:\n`);
@@ -39,7 +45,9 @@ export class ForwardAnalysisTypeInference {
 	}
 
 	joinBranches(first, others, node) {
-		return this._withTypeEnvironment(first, () => this.hindleyMilner.mergeWithTypeEnvironments(others, node.value || {}));
+		const context = new TypeInferenceContext(this._program, first);
+		this._hindleyMilner.mergeWithTypeEnvironments(others, node.value || {}, context);
+		return context.typeEnvironment;
 	}
 
 	/**
@@ -52,16 +60,6 @@ export class ForwardAnalysisTypeInference {
      */
 	areLatticesEqual(env1, env2) {
 		return env1 === env2;
-	}
-
-	_withTypeEnvironment(environment, callback) {
-		this.hindleyMilner.typeEnvironment = environment;
-		try {
-			callback();
-			return this.hindleyMilner.typeEnvironment;
-		} finally {
-			this.hindleyMilner.typeEnvironment = TypeEnvironment.EMPTY;
-		}
 	}
 }
 

--- a/lib/type-inference/hindley-milner.js
+++ b/lib/type-inference/hindley-milner.js
@@ -3,9 +3,8 @@ import assert from "assert";
 
 import {globRequireInstances} from "../util";
 import TypeUnificator from "./type-unificator";
-import RefinementContext from "./refinment-context";
+import RefinementContext from "./refinement-context";
 import {TypeInferenceError} from "./type-inference-error";
-import {TypeEnvironment} from "./type-environment";
 
 /**
  * Interface for a refinement rule used by the Hindley Milner algorithm.
@@ -31,25 +30,12 @@ import {TypeEnvironment} from "./type-environment";
  */
 export class HindleyMilner {
 	/**
-	 * Creates a new instance of the hindley milner algorithm that operates on the given type environment and uses
-	 * the given symbol table for resolving symbols
+	 * Creates a new instance of the hindley milner algorithm.
 	 * @param {Program} program the analyzed program
-	 * @param {TypeEnvironment} typeEnvironment the type environment to use in this analysis
 	 * @param {TypeUnificator} unificator the unificator to use for unifying the types
 	 * @param {RefinementRule[]} refinementRules the rules that should be applied to refine the types
      */
-	constructor(program, typeEnvironment=new TypeEnvironment(), unificator=new TypeUnificator(), refinementRules=globRequireInstances("./refinement-rules/*-refinement-rule.js", module)) {
-		/**
-		 * The type environment
-		 * @type {TypeEnvironment}
-         */
-		this.typeEnvironment = typeEnvironment;
-
-		/**
-		 * The program for which the analysis is executed
-		 * @type {Program}
-         */
-		this.program = program;
+	constructor(unificator=new TypeUnificator(), refinementRules=globRequireInstances("./refinement-rules/*-refinement-rule.js", module)) {
 
 		/**
 		 * The unificator used to unify two types
@@ -67,11 +53,13 @@ export class HindleyMilner {
 	/**
 	 * Infers the types for the passed in expression / node and all it's children.
 	 * @param {Node} e the node for which the type should be interfered
+	 * @param {TypeInferenceContext} context the context in which the type inference is performed.
 	 * @returns {Type} the type of the node.
      */
-	infer(e) {
-		assert(e, "A node for which the types should be infered is required");
-		return this._getRefinementRule(e).refine(e, new RefinementContext(this));
+	infer(e, context) {
+		assert(e, "A node for which the types should be inferred is required");
+		assert(context, "A type inference context is required");
+		return this._getRefinementRule(e).refine(e, new RefinementContext(this, context));
 	}
 
 	/**
@@ -79,14 +67,16 @@ export class HindleyMilner {
 	 * @param {Type} t1 the type 1
 	 * @param {Type} t2 a second type
 	 * @param {Node} node the node for which the unification of the type is performed, needed in error messages
+	 * @param {TypeInferenceContext} context the context for the unification
 	 * @returns {Type} the most specific common type if the types are compatible
 	 * @throws if the two types cannot be unified, e.g. if one type is a string and another is a number or
 	 * if the types are relative to each other (t1=T, t2=S->T, in this case t1 cannot be expressed by T2, neither can t2 be expressed by t1)
      */
-	unify(t1, t2, node) {
+	unify(t1, t2, node, context) {
 		assert(t1, "The type t1 to unify needs to be specified");
 		assert(t2, "The type t2 to unify needs to be specified");
 		assert(node, "The node for which the types are to be unified needs to be specified");
+		assert(context, "The context for the unification is not optional");
 
 		try {
 			const unified = this.unificator.unify(t1, t2);
@@ -95,11 +85,11 @@ export class HindleyMilner {
 			// has exactly one type and the one does not change. But cases like the one above let us change the type at a later
 			// position.
 			if (!t1.equals(unified)) {
-				this._substitute(t1, unified);
+				context.substitute(t1, unified);
 			}
 
 			if (!t2.equals(unified)) {
-				this._substitute(t2, unified);
+				context.substitute(t2, unified);
 			}
 
 			return unified;
@@ -114,25 +104,19 @@ export class HindleyMilner {
 	 * all type environments, whereas conflicting definitions are unified.
 	 * @param {TypeEnvironment[]} others the other type environments with which this environment should be merged
 	 * @param node the ast node for which the merge is performed
-	 * @returns {TypeEnvironment} the merged type environment
+	 * @param {TypeInferenceContext} context the type inference context that provides the type environment for the merge
      */
-	mergeWithTypeEnvironments(others, node) {
+	mergeWithTypeEnvironments(others, node, context) {
 		for (const other of others) {
 			for (const [symbol, type] of other.mappings) {
-				const mergedType = this.typeEnvironment.getType(symbol);
+				const mergedType = context.getType(symbol);
 				if (!mergedType) {
-					this.typeEnvironment = this.typeEnvironment.setType(symbol, type);
+					context.setType(symbol, type);
 				} else {
-					this._substitute(mergedType, this.unify(type, mergedType, node));
+					context.substitute(mergedType, this.unify(type, mergedType, node, context));
 				}
 			}
 		}
-
-		return this.typeEnvironment;
-	}
-
-	_substitute(t1, t2) {
-		this.typeEnvironment = this.typeEnvironment.substitute(t1, t2);
 	}
 
 	_getRefinementRule(node) {

--- a/lib/type-inference/refinement-context.js
+++ b/lib/type-inference/refinement-context.js
@@ -1,4 +1,3 @@
-
 /**
  * Context with additional parameters passed to the refinement function of a RefinementRule.
  */
@@ -6,46 +5,21 @@ export class RefinementContext {
 	/**
 	 * Creates a new refinement context for the given Hindley Milner instance
 	 * @param {HindleyMilner} hindleyMilner the hindley milner instance
+	 * @param {TypeInferenceContext} typeInferenceContext the type inference context that is to be used for the refinement
      */
-	constructor(hindleyMilner) {
+	constructor(hindleyMilner, typeInferenceContext) {
 		this._hindleyMilner = hindleyMilner;
-	}
-
-	/**
-	 * Resolves the type for the given symbol from the type environment
-	 * @param {Symbol} symbol the symbol for which the type should be resolved
-	 * @returns {Type} the resolved type or undefined
-	 */
-	getType(symbol) {
-		return this._hindleyMilner.typeEnvironment.getType(symbol);
-	}
-
-	/**
-	 * Sets the type for the given symbol
-	 * @param {Symbol} symbol the symbol for which the type should be set in the type environment
-	 * @param {Type} type the type of the symbol
-	 */
-	setType(symbol, type) {
-		this._hindleyMilner.typeEnvironment = this._hindleyMilner.typeEnvironment.setType(symbol, type);
-	}
-
-	/**
-	 * Replaces the type associated with the given symbol in the type environment (and all it's usages in parametrized types).
-	 * @param {Symbol} symbol the symbol for which the type should be replaced
-	 * @param {function (oldType: Type): Type} callback callback that is invoked with the old type and returns the new type
-	 * for the given symbol
-     */
-	replaceType(symbol, callback) {
-		this._hindleyMilner.typeEnvironment = this._hindleyMilner.typeEnvironment.replaceType(symbol, callback);
+		this._typeInferenceContext = typeInferenceContext;
 	}
 
 	/**
 	 * Infers the type for the given ast node
 	 * @param {Node} node the ast node for which the type needs to be determined
-	 * @returns {Type} the infered type for the given name
+	 * @param {TypeInferenceContext} [context=this] the type inference context that should be used to infer the type
+	 * @returns {Type} the inferred type for the given name
 	 */
-	infer(node) {
-		return this._hindleyMilner.infer(node);
+	infer(node, context=this._typeInferenceContext) {
+		return this._hindleyMilner.infer(node, context);
 	}
 
 	/**
@@ -57,7 +31,35 @@ export class RefinementContext {
 	 * @throws UnificationError if the unification of type t1 and t2 is not possible.
 	 */
 	unify(t1, t2, node) {
-		return this._hindleyMilner.unify(t1, t2, node);
+		return this._hindleyMilner.unify(t1, t2, node, this._typeInferenceContext);
+	}
+
+	/**
+	 * Resolves the type for the given symbol from the type environment
+	 * @param {Symbol} symbol the symbol for which the type should be resolved
+	 * @returns {Type} the resolved type or undefined
+	 */
+	getType(symbol) {
+		return this._typeInferenceContext.getType(symbol);
+	}
+
+	/**
+	 * Sets the type for the given symbol
+	 * @param {Symbol} symbol the symbol for which the type should be set in the type environment
+	 * @param {Type} type the type of the symbol
+	 */
+	setType(symbol, type) {
+		this._typeInferenceContext.setType(symbol, type);
+	}
+
+	/**
+	 * Replaces the type associated with the given symbol in the type environment (and all it's usages in parametrized types).
+	 * @param {Symbol} symbol the symbol for which the type should be replaced
+	 * @param {function (oldType: Type): Type} callback callback that is invoked with the old type and returns the new type
+	 * for the given symbol
+	 */
+	replaceType(symbol, callback) {
+		this._typeInferenceContext.replaceType(symbol, callback);
 	}
 
 	/**
@@ -66,16 +68,16 @@ export class RefinementContext {
 	 * @returns {Symbol} the symbol for the node or undefined if the node has no symbol (e.g. a binary expression has no symbol)
 	 */
 	getSymbol(node) {
-		return this._hindleyMilner.program.symbolTable.getSymbol(node);
+		return this._typeInferenceContext.getSymbol(node);
 	}
 
 	/**
 	 * Returns the control flow graph for the given node
 	 * @param node the node for which the control flow graph is needed
 	 * @returns {ControlFlowGraph} the control flow graph
-     */
+	 */
 	getCfg(node) {
-		return this._hindleyMilner.program.getCfg(node);
+		return this._typeInferenceContext.getCfg(node);
 	}
 }
 

--- a/lib/type-inference/type-inference-context.js
+++ b/lib/type-inference/type-inference-context.js
@@ -1,0 +1,84 @@
+import TypeEnvironment from "./type-environment";
+
+/**
+ * The type inference context provides the context in which the type inference is performed.
+ * This is mainly the type environment that defines the types that are refined up to the current position.
+ * It provides access to the symbol table and the control flow graph at the other hand
+ */
+export class TypeInferenceContext {
+	/**
+	 * Creates a new instance for the type inference of the given program starting with the given type environment.
+	 * The type environment will be refined and therefor replaced during the type inference analysis.
+	 * @param {Program} program the program for which the analysis is performed
+	 * @param {TypeEnvironment} [typeEnvironment=EMPTY] the start type environment for this context
+     */
+	constructor(program, typeEnvironment=TypeEnvironment.EMPTY) {
+		/**
+		 * The program for which the type inference is performed
+		 * @type {Program}
+         */
+		this.program = program;
+
+		/**
+		 * The type environment that holds the mapping from the symbols to the types that have been inferred up to the current state.
+		 * The reference of the type environment changes every time a type has been refined.
+		 * @type {TypeEnvironment}
+         */
+		this.typeEnvironment = typeEnvironment;
+	}
+
+	/**
+	 * Resolves the type for the given symbol from the type environment
+	 * @param {Symbol} symbol the symbol for which the type should be resolved
+	 * @returns {Type} the resolved type or undefined
+	 */
+	getType(symbol) {
+		return this.typeEnvironment.getType(symbol);
+	}
+
+	/**
+	 * Sets the type for the given symbol
+	 * @param {Symbol} symbol the symbol for which the type should be set in the type environment
+	 * @param {Type} type the type of the symbol
+	 */
+	setType(symbol, type) {
+		this.typeEnvironment = this.typeEnvironment.setType(symbol, type);
+	}
+
+	/**
+	 * Replaces the type associated with the given symbol in the type environment (and all it's usages in parametrized types).
+	 * @param {Symbol} symbol the symbol for which the type should be replaced
+	 * @param {function (oldType: Type): Type} callback callback that is invoked with the old type and returns the new type
+	 * for the given symbol
+	 */
+	replaceType(symbol, callback) {
+		this.typeEnvironment = this.typeEnvironment.replaceType(symbol, callback);
+	}
+
+	/**
+	 * Substitutes the type t1 with the type t2
+	 * @param {Type} t1 the type that should be substituted
+	 * @param {Type} t2 the type that substitutes t1
+     */
+	substitute(t1, t2) {
+		this.typeEnvironment = this.typeEnvironment.substitute(t1, t2);
+	}
+
+	/**
+	 * Returns the symbol for a node
+	 * @param {Node} node the ast node for which the symbol should be retrieved
+	 * @returns {Symbol} the symbol for the node or undefined if the node has no symbol (e.g. a binary expression has no symbol)
+	 */
+	getSymbol(node) {
+		return this.program.symbolTable.getSymbol(node);
+	}
+
+	/**
+	 * Returns the control flow graph for the given node
+	 * @param node the node for which the control flow graph is needed
+	 * @returns {ControlFlowGraph} the control flow graph
+	 */
+	getCfg(node) {
+		return this.program.getCfg(node);
+	}
+}

--- a/test/type-inference/refinement-context.spec.js
+++ b/test/type-inference/refinement-context.spec.js
@@ -3,94 +3,62 @@ import sinon from "sinon";
 
 import {Program} from "../../lib/semantic-model/program";
 import Symbol, {SymbolFlags} from "../../lib/semantic-model/symbol";
-import {RefinementContext} from "../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../lib/type-inference/refinement-context";
 import {HindleyMilner} from "../../lib/type-inference/hindley-milner";
-import {TypeEnvironment} from "../../lib/type-inference/type-environment";
-import {NumberType} from "../../lib/semantic-model/types";
+import {NumberType, StringType} from "../../lib/semantic-model/types";
+import {TypeInferenceContext} from "../../lib/type-inference/type-inference-context";
 
 describe("RefinementContext", function () {
 	let hindleyMilner,
-		typeEnvironment,
-		symbolTable,
 		program,
+		typeInferenceContext,
 		refinementContext;
 
 	beforeEach(function () {
 		program = new Program();
-		symbolTable = program.symbolTable;
-		typeEnvironment = new TypeEnvironment();
-		hindleyMilner = new HindleyMilner(program, typeEnvironment, null, []);
-		refinementContext = new RefinementContext(hindleyMilner);
+		hindleyMilner = new HindleyMilner(null, []);
+		typeInferenceContext = new TypeInferenceContext(program);
+		refinementContext = new RefinementContext(hindleyMilner, typeInferenceContext);
 	});
 
 	describe("getType", function () {
-		it("returns the type from the type environment", function () {
+		it("returns the type from the type inference context", function () {
 			// arrange
 			const symbol = new Symbol("x", SymbolFlags.Variable);
 			const type = new NumberType();
-			sinon.stub(typeEnvironment, "getType").returns(type);
+			typeInferenceContext.setType(symbol, type);
 
 			// act, assert
 			expect(refinementContext.getType(symbol)).to.equal(type);
-			sinon.assert.calledWith(typeEnvironment.getType, symbol);
 		});
 	});
 
 	describe("setType", function () {
-		it("sets the type in the type environment", function () {
+		it("sets the type in the type inference context", function () {
 			// arrange
 			const symbol = new Symbol("x", SymbolFlags.Variable);
 			const type = new NumberType();
-			sinon.stub(typeEnvironment, "setType");
 
 			// act
 			refinementContext.setType(symbol, type);
 
 			// assert
-			sinon.assert.calledWith(typeEnvironment.setType, symbol, type);
-		});
-
-		it("replaces the type environment with the returned environment from set type", function () {
-			// arrange
-			const symbol = new Symbol("x", SymbolFlags.Variable);
-			const type = new NumberType();
-			const newTypeEnvironment = {};
-			sinon.stub(typeEnvironment, "setType").returns(newTypeEnvironment);
-
-			// act
-			refinementContext.setType(symbol, type);
-
-			// assert
-			expect(hindleyMilner.typeEnvironment).to.equal(newTypeEnvironment);
+			expect(typeInferenceContext.getType(symbol)).to.equal(type);
 		});
 	});
 
 	describe("replaceType", function () {
-		it("replaces the type in the type environment", function () {
+		it("replaces the type in the type inference context", function () {
 			// arrange
 			const symbol = new Symbol("x", SymbolFlags.Variable);
 			const type = new NumberType();
-			sinon.stub(typeEnvironment, "replaceType");
+			typeInferenceContext.setType(symbol, type);
 
 			// act
-			refinementContext.replaceType(symbol, () => type);
+			refinementContext.replaceType(symbol, () => new StringType());
 
 			// assert
-			sinon.assert.calledWith(typeEnvironment.replaceType, symbol);
-		});
-
-		it("replaces the type environment with the returned environment from repalce type", function () {
-			// arrange
-			const symbol = new Symbol("x", SymbolFlags.Variable);
-			const type = new NumberType();
-			const newTypeEnvironment = {};
-			sinon.stub(typeEnvironment, "replaceType").returns(newTypeEnvironment);
-
-			// act
-			refinementContext.replaceType(symbol, () => type);
-
-			// assert
-			expect(hindleyMilner.typeEnvironment).to.equal(newTypeEnvironment);
+			expect(typeInferenceContext.getType(symbol)).to.be.instanceOf(StringType);
 		});
 	});
 
@@ -106,7 +74,7 @@ describe("RefinementContext", function () {
 			const inferred = refinementContext.infer(node);
 
 			// assert
-			sinon.assert.calledWith(hindleyMilner.infer, node);
+			sinon.assert.calledWith(hindleyMilner.infer, node, typeInferenceContext);
 			expect(inferred).to.equal(type);
 		});
 	});
@@ -124,38 +92,38 @@ describe("RefinementContext", function () {
 			const unified = refinementContext.unify(type1, type2, node);
 
 			// assert
-			sinon.assert.calledWith(hindleyMilner.unify, type1, type2, node);
+			sinon.assert.calledWith(hindleyMilner.unify, type1, type2, node, typeInferenceContext);
 			expect(unified).to.equal(type1);
 		});
 	});
 
 	describe("getSymbol", function () {
-		it("resolves the symbol from the symbol table of the program", function () {
+		it("resolves the symbol using the inference context", function () {
 			// arrange
 			const node = {};
 			const symbol = new Symbol("x", SymbolFlags.Variable);
 
-			sinon.stub(symbolTable, "getSymbol").returns(symbol);
+			sinon.stub(typeInferenceContext, "getSymbol").returns(symbol);
 
 			// act
 			const resolvedSymbol = refinementContext.getSymbol(node);
 
 			// assert
-			sinon.assert.calledWith(symbolTable.getSymbol, node);
+			sinon.assert.calledWith(typeInferenceContext.getSymbol, node);
 			expect(resolvedSymbol).to.equal(symbol);
 		});
 	});
 
 	describe("getCfg", function () {
-		it("resolves the cfg by using program.getCfg", function () {
+		it("resolves the cfg by using the inference context", function () {
 			const node = {};
-			sinon.stub(program, "getCfg");
+			sinon.stub(typeInferenceContext, "getCfg");
 
 			// act
 			refinementContext.getCfg(node);
 
 			// assert
-			sinon.assert.calledWith(program.getCfg, node);
+			sinon.assert.calledWith(typeInferenceContext.getCfg, node);
 		});
 	});
 });

--- a/test/type-inference/refinment-rules/binary-expression-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/binary-expression-refinement-rule.spec.js
@@ -5,14 +5,15 @@ import sinon from "sinon";
 import BINARY_OPERATORS from "../../../lib/type-inference/refinement-rules/binary-operators";
 import {BinaryExpressionRefinementRule} from "../../../lib/type-inference/refinement-rules/binary-expression-refinement-rule";
 import {NullType, NumberType} from "../../../lib/semantic-model/types";
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
+import {TypeInferenceContext} from "../../../lib/type-inference/type-inference-context";
 
 describe("BinaryExpressionRefinementRule", function () {
-	let rule, context, sandbox;
+	let rule, context, sandbox, program;
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
-		context = new RefinementContext();
+		context = new RefinementContext(null, new TypeInferenceContext(program));
 		sandbox.stub(context, "infer");
 		rule = new BinaryExpressionRefinementRule();
 	});

--- a/test/type-inference/refinment-rules/block-statement-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/block-statement-refinement-rule.spec.js
@@ -24,7 +24,7 @@ describe("BlockStatementRefinementRule", function () {
 
 	describe("refine", function () {
 		it("returns VoidType", function () {
-			expect(rule.refine(blockStatement, context)).to.be.instanceOf(VoidType);
+			expect(rule.refine(blockStatement, null)).to.be.instanceOf(VoidType);
 		});
 	});
 });

--- a/test/type-inference/refinment-rules/expression-statement-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/expression-statement-refinement-rule.spec.js
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import * as t from "babel-types";
 
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {ExpressionStatementRefinementRule} from "../../../lib/type-inference/refinement-rules/expression-statement-refinement-rule";
 import {VoidType} from "../../../lib/semantic-model/types";
 

--- a/test/type-inference/refinment-rules/if-statement-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/if-statement-refinement-rule.spec.js
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import * as t from "babel-types";
 
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {IfStatementRefinementRule} from "../../../lib/type-inference/refinement-rules/if-statement-refinement-rule";
 import {VoidType} from "../../../lib/semantic-model/types";
 

--- a/test/type-inference/refinment-rules/member-expression-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/member-expression-refinement-rule.spec.js
@@ -4,18 +4,19 @@ import * as t from "babel-types";
 
 import {Symbol, SymbolFlags} from "../../../lib/semantic-model/symbol";
 import {StringType, RecordType, VoidType} from "../../../lib/semantic-model/types";
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {MemberExpressionRefinementRule} from "../../../lib/type-inference/refinement-rules/member-expression-refinement-rule";
+import {TypeInferenceContext} from "../../../lib/type-inference/type-inference-context";
+import {Program} from "../../../lib/semantic-model/program";
 
 describe("MemberExpressionRefinementRule", function () {
-	let rule, context, memberExpression, sandbox;
+	let rule, context, program, memberExpression, sandbox;
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
-		context = new RefinementContext();
+		program = new Program();
+		context = new RefinementContext(null, new TypeInferenceContext(program));
 
-		sandbox.stub(context, "getType");
-		sandbox.stub(context, "getSymbol");
 		sandbox.stub(context, "unify");
 
 		rule = new MemberExpressionRefinementRule();
@@ -43,11 +44,11 @@ describe("MemberExpressionRefinementRule", function () {
 			const nameSymbol = new Symbol("name", SymbolFlags.Property);
 			personSymbol.addMember(nameSymbol);
 
-			context.getSymbol.withArgs(memberExpression.object).returns(personSymbol);
-			context.getSymbol.withArgs(memberExpression.property).returns(nameSymbol);
+			program.symbolTable.setSymbol(memberExpression.object, personSymbol);
+			program.symbolTable.setSymbol(memberExpression.property, nameSymbol);
 
 			const personType = RecordType.withProperties([[nameSymbol, new StringType()]]);
-			context.getType.withArgs(personSymbol).returns(personType);
+			context.setType(personSymbol, personType);
 
 			context.unify.withArgs(RecordType.ANY, personType).returns(personType);
 
@@ -70,11 +71,11 @@ describe("MemberExpressionRefinementRule", function () {
 			const personSymbol = new Symbol("person", SymbolFlags.Variable);
 			personSymbol.addMember(nameSymbol);
 
-			context.getSymbol.withArgs(memberExpression.property).returns(nameSymbol);
-			context.getSymbol.withArgs(memberExpression.object).returns(personSymbol);
+			program.symbolTable.setSymbol(memberExpression.object, personSymbol);
+			program.symbolTable.setSymbol(memberExpression.property, nameSymbol);
 
 			const personType = new RecordType();
-			context.getType.withArgs(personSymbol).returns(personType);
+			context.setType(personSymbol, personType);
 
 			context.unify.withArgs(RecordType.ANY, personType).returns(personType);
 
@@ -95,8 +96,8 @@ describe("MemberExpressionRefinementRule", function () {
 			const personSymbol = new Symbol("person", SymbolFlags.Variable);
 			personSymbol.addMember(nameSymbol);
 
-			context.getSymbol.withArgs(memberExpression.property).returns(nameSymbol);
-			context.getSymbol.withArgs(memberExpression.object).returns(personSymbol);
+			program.symbolTable.setSymbol(memberExpression.object, personSymbol);
+			program.symbolTable.setSymbol(memberExpression.property, nameSymbol);
 
 			context.unify.withArgs(RecordType.ANY).returns(new RecordType());
 

--- a/test/type-inference/refinment-rules/object-expression-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/object-expression-refinement-rule.spec.js
@@ -2,19 +2,21 @@ import {expect} from "chai";
 import sinon from "sinon";
 import * as t from "babel-types";
 
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {ObjectExpressionRefinementRule} from "../../../lib/type-inference/refinement-rules/object-expression-refinement-rule";
 import {NumberType, StringType, RecordType} from "../../../lib/semantic-model/types";
 import {Symbol, SymbolFlags} from "../../../lib/semantic-model/symbol";
+import {Program} from "../../../lib/semantic-model/program";
+import {TypeInferenceContext} from "../../../lib/type-inference/type-inference-context";
 
 describe("ObjectExpressRefinementRule", function () {
-	let rule, context, objectExpression, sandbox;
+	let rule, context, program, objectExpression, sandbox;
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
-		context = new RefinementContext();
+		program = new Program();
+		context = new RefinementContext(null, new TypeInferenceContext(program));
 		sandbox.stub(context, "infer");
-		sandbox.stub(context, "getSymbol");
 
 		rule = new ObjectExpressionRefinementRule();
 		objectExpression = t.objectExpression([
@@ -44,8 +46,8 @@ describe("ObjectExpressRefinementRule", function () {
 		beforeEach(function () {
 			context.infer.withArgs(objectExpression.properties[0].value).returns(new StringType());
 			context.infer.withArgs(objectExpression.properties[1].value).returns(new NumberType());
-			context.getSymbol.withArgs(objectExpression.properties[0]).returns(name);
-			context.getSymbol.withArgs(objectExpression.properties[1]).returns(age);
+			program.symbolTable.setSymbol(objectExpression.properties[0], name);
+			program.symbolTable.setSymbol(objectExpression.properties[1], age);
 		});
 
 		it("returns a record type", function () {

--- a/test/type-inference/refinment-rules/unary-statement-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/unary-statement-refinement-rule.spec.js
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import * as t from "babel-types";
 import {UnaryExpressionRefinementRule} from "../../../lib/type-inference/refinement-rules/unary-expression-refinement-rule";
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {NumberType, VoidType, BooleanType, NullType, MaybeType} from "../../../lib/semantic-model/types";
 
 describe("UnaryExpressionRefinementRule", function () {

--- a/test/type-inference/type-inference-context.spec.js
+++ b/test/type-inference/type-inference-context.spec.js
@@ -1,0 +1,111 @@
+import {expect} from "chai";
+import sinon from "sinon";
+import {TypeInferenceContext} from "../../lib/type-inference/type-inference-context";
+import {Symbol, SymbolFlags } from "../../lib/semantic-model/symbol";
+import {StringType, NumberType} from "../../lib/semantic-model/types";
+import {TypeEnvironment} from "../../lib/type-inference/type-environment";
+import {Program} from "../../lib/semantic-model/program";
+import {ControlFlowGraph} from "../../lib/cfg/control-flow-graph";
+
+describe("TypeInferenceContext", function () {
+	let program;
+
+	beforeEach(function () {
+		program = new Program();
+	});
+
+	describe("getType", function () {
+		it("returns the type for the given symbol from the underlining type environment", function () {
+			// arrange
+			const x = new Symbol("x", SymbolFlags.Identifier);
+			const xType = new StringType();
+			const typeEnvironment = new TypeEnvironment().setType(x, xType);
+			const context = new TypeInferenceContext(program, typeEnvironment);
+
+			// assert
+			expect(context.getType(x)).to.equal(xType);
+		});
+	});
+
+	describe("setType", function () {
+		it("sets the type in the type environment", function () {
+			// arrange
+			const x = new Symbol("x", SymbolFlags.Identifier);
+			const xType = new StringType();
+			const context = new TypeInferenceContext(program);
+
+			// act
+			context.setType(x, xType);
+
+			// assert
+			expect(context.typeEnvironment.getType(x)).to.equal(xType);
+		});
+	});
+
+	describe("replaceType", function () {
+		it("replaces the type in the type environment", function () {
+			// arrange
+			const x = new Symbol("x", SymbolFlags.Identifier);
+			const typeEnvironment = new TypeEnvironment().setType(x, new StringType());
+			const context = new TypeInferenceContext(program, typeEnvironment);
+
+			const newType = new NumberType();
+			sinon.spy(typeEnvironment, "replaceType");
+
+			// act
+			context.replaceType(x, () => newType);
+
+			// assert
+			expect(context.getType(x)).to.equal(newType);
+			sinon.assert.calledWith(typeEnvironment.replaceType, x);
+		});
+	});
+
+	describe("substitute", function () {
+		it("calls substitute on the type environment", function () {
+			// arrange
+			const t1 = new StringType();
+			const t2 = new NumberType();
+			const typeEnvironment = new TypeEnvironment();
+			context = new TypeInferenceContext(program, typeEnvironment);
+
+			sinon.spy(typeEnvironment, "substitute");
+
+			// act
+			context.substitute(t1, t2);
+
+			// assert
+			sinon.assert.calledWith(typeEnvironment.substitute, t1, t2);
+		});
+	});
+
+	describe("getSymbol", function () {
+		it("returns the symbol from the programs symbol table", function () {
+			// arrange
+			const node = {};
+			const symbol = new Symbol("x", SymbolFlags.Variable);
+
+			program.symbolTable.setSymbol(node, symbol);
+
+			const context = new TypeInferenceContext(program);
+
+			// act, assert
+			expect(context.getSymbol(node)).to.equal(symbol);
+		});
+	});
+
+	describe("getCfg", function () {
+		it("returns the cfg determined by program.getCfg", function () {
+			// arrange
+			const node = {};
+			const cfg = new ControlFlowGraph();
+
+			sinon.stub(program, "getCfg").returns(cfg);
+
+			const context = new TypeInferenceContext(program);
+
+			// act, assert
+			expect(context.getCfg(node)).to.equal(cfg);
+		});
+	});
+});

--- a/test/type-inference/unification-rules/parametrized-types-unification-rule.spec.js
+++ b/test/type-inference/unification-rules/parametrized-types-unification-rule.spec.js
@@ -3,7 +3,7 @@ import sinon from "sinon";
 
 import ParametrizedTypesUnificationRule from "../../../lib/type-inference/unification-rules/parametrized-types-unification-rule";
 import {NumberType, ParametrizedType, StringType} from "../../../lib/semantic-model/types/index";
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 
 describe("ParametrizedTypesUnificationRule", function () {
 	let rule, context;

--- a/test/type-inference/unification-rules/record-unification-rule.spec.js
+++ b/test/type-inference/unification-rules/record-unification-rule.spec.js
@@ -2,7 +2,7 @@ import sinon from "sinon";
 import {expect} from "chai";
 
 import {RecordUnificationRule} from "../../../lib/type-inference/unification-rules/record-unification-rule";
-import {RefinementContext} from "../../../lib/type-inference/refinment-context";
+import {RefinementContext} from "../../../lib/type-inference/refinement-context";
 import {SymbolFlags, Symbol} from "../../../lib/semantic-model/symbol";
 import {StringType, RecordType, NumberType, NullType, MaybeType} from "../../../lib/semantic-model/types";
 


### PR DESCRIPTION
The Call expression refinement rule needs to be able to specify a specific type environment that should be used for the function inference (let polymorphism). Therefore it needs to be possible that the refinement rule can pass the type environment to use in `context.infer`. 