### PR TITLE
Implement a more sophistic recursion detection

### DIFF
--- a/lib/semantic-model/types/type-variable.js
+++ b/lib/semantic-model/types/type-variable.js
@@ -17,7 +17,7 @@ export class TypeVariable extends Type {
 	}
 
 	fresh() {
-		return this;
+		return new TypeVariable();
 	}
 
 	/**

--- a/lib/type-inference/refinement-rules/binary-expression-refinement-rule.js
+++ b/lib/type-inference/refinement-rules/binary-expression-refinement-rule.js
@@ -16,8 +16,9 @@ export class BinaryExpressionRefinementRule {
 		}
 		const operator = BINARY_OPERATORS[node.operator];
 
-		const leftExpressionType = context.infer(node.left);
-		const rightExpressionType = context.infer(node.right);
+		// Use fresh types. This operations should not change the effective type of a variable. If the variable was null before, then it should still be null.
+		const leftExpressionType = context.infer(node.left).fresh();
+		const rightExpressionType = context.infer(node.right).fresh();
 		return operator.refine(leftExpressionType, rightExpressionType, (t1, t2) => context.unify(t1, t2, node));
 	}
 }

--- a/lib/type-inference/refinement-rules/call-expression-refinement-rule.js
+++ b/lib/type-inference/refinement-rules/call-expression-refinement-rule.js
@@ -1,3 +1,4 @@
+import * as _ from "lodash";
 import {VoidType, FunctionType} from "../../semantic-model/types";
 import {TypeInferenceError} from "../type-inference-error";
 import {Symbol} from "../../semantic-model/symbol";
@@ -27,44 +28,61 @@ export class CallExpressionRefinementRule {
 	 * @param {HindleyMilnerContext} calleeContext
      */
 	refine(node, calleeContext) {
-		const functionType = this.getFunctionType(calleeContext, node);
-		const functionDeclaration = functionType.declaration;
-
-		const callCount = this.callCounts.get(functionDeclaration) || 0;
-
-		if (callCount > 20) {
-			if (!(functionType.returnType instanceof TypeVariable)) {
-				return functionType.returnType;
-			}
-			// a little bit more complicated...
-			return new AnyType();
-		}
-
-		try {
-			this.callCounts.set(functionDeclaration, callCount + 1);
-			return this._invokeFunction(functionDeclaration, node, calleeContext);
-		} finally {
-			this.callCounts.set(functionDeclaration, callCount - 1);
-		}
-	}
-
-	_invokeFunction(functionDeclaration, callExpression, calleeContext) {
 		// use a new context in with the function body is inferred to not change the function signature
 		// and avoid pollution of callee's type environment.
-		const functionContext = calleeContext.fresh();
+		const callContext = calleeContext.fresh();
+		const functionType = this._getCalleeType(calleeContext, node);
+		const functionDeclaration = functionType.declaration;
 
+		const invocation = this._createInvocation(node, functionDeclaration, calleeContext, callContext);
+		const invocations = this._getInvocations(functionDeclaration);
 
-		functionContext.setType(Symbol.THIS, this._thisType(callExpression, calleeContext));
-		this._declareParameters(callExpression, functionDeclaration, calleeContext, functionContext);
+		// there exists an invocation that seems to be equal to this one, so the return type should also be equal
+		// (and parameter verification should also fail for that invocation if they do not fulfil the premises of the signature
+		const equalInvocation = _.find(invocations, other => other.equals(invocation));
 
-		functionContext.analyse(functionDeclaration.body);
+		// If a previous invocation was strictly equal, then return the same return type result.
+		if (equalInvocation) {
+			return equalInvocation.context.getType(Symbol.RETURN);
+		}
 
-		this._updateArgumentTypesInCalleeContext(callExpression, functionDeclaration, calleeContext, functionContext);
+		// recursive call, depth > 20;
+		if (invocations.length > 20) {
+			return this._endRecursion(functionType);
+		}
 
-		return functionContext.getType(Symbol.RETURN) || new VoidType();
+		// non recursive call or recursive call with depth < 20
+		try {
+			invocations.push(invocation);
+			return this._invokeFunction(functionType, node, calleeContext, callContext);
+		} finally {
+			_.pull(invocations, invocation);
+		}
 	}
 
-	getFunctionType(calleeContext, node) {
+	_getInvocations(functionDeclaration) {
+		let invocations = this.callCounts.get(functionDeclaration);
+		if (!invocations) {
+			invocations = [];
+			this.callCounts.set(functionDeclaration, invocations);
+		}
+		return invocations;
+	}
+
+	_invokeFunction(functionType, callExpression, callerContext, callContext) {
+		const functionDeclaration = functionType.declaration;
+		callContext.setType(Symbol.RETURN, functionType.returnType.fresh());
+		callContext.setType(Symbol.THIS, this._getThisType(callExpression, callerContext));
+		this._declareParameters(callExpression, functionDeclaration, callerContext, callContext);
+
+		callContext.analyse(functionDeclaration.body);
+
+		this._updateArgumentTypesInCalleeContext(callExpression, functionDeclaration, callerContext, callContext);
+
+		return callContext.getType(Symbol.RETURN);
+	}
+
+	_getCalleeType(calleeContext, node) {
 		const functionType = this._getNodeType(node.callee, calleeContext);
 
 		if (!(functionType instanceof FunctionType)) {
@@ -80,12 +98,20 @@ export class CallExpressionRefinementRule {
 	 * @param context the call context
 	 * @private
      */
-	_thisType(node, context) {
+	_getThisType(node, context) {
 		if (node.callee.type === "MemberExpression") {
 			return context.getObjectType(node.callee);
 		}
 
 		return new VoidType();
+	}
+
+	_endRecursion(functionType) {
+		if (!(functionType.returnType instanceof TypeVariable)) {
+			return functionType.returnType;
+		}
+		// a little bit more complicated...
+		return new AnyType();
 	}
 
 	/**
@@ -139,8 +165,7 @@ export class CallExpressionRefinementRule {
 			}
 		}
 	}
-
-
+	
 	_getNodeType(node, context) {
 		let result;
 		const nodeSymbol = context.getSymbol(node);
@@ -161,6 +186,38 @@ export class CallExpressionRefinementRule {
 		return result || new VoidType();
 	}
 
+	_createInvocation(call, functionDeclaration, context, calleeContext) {
+		const args = call.arguments.map(argument => this._getNodeType(argument, context));
+		return new Invocation(functionDeclaration, args, calleeContext);
+	}
+}
+
+/**
+ * Snapshot for a function invocation. Stores the node of the invoked function, the types of the arguments
+ * and the context of the invocation (callee).
+ */
+class Invocation {
+	constructor(func, argumentTypes, calleeContext) {
+		this.function = func;
+		this.argumentTypes = argumentTypes;
+		this.context = calleeContext;
+	}
+
+	equals(other) {
+		if (this === other) {
+			return true;
+		}
+
+		if (other.function !== this.function) {
+			return false;
+		}
+
+		if (this.argumentTypes.length !== other.argumentTypes.length) {
+			return false;
+		}
+
+		return _.zip(this.argumentTypes, other.argumentTypes).every(([x, y]) => x.equals(y));
+	}
 }
 
 export default CallExpressionRefinementRule;

--- a/lib/type-inference/refinement-rules/return-statement-refinement-rule.js
+++ b/lib/type-inference/refinement-rules/return-statement-refinement-rule.js
@@ -23,7 +23,6 @@ export class ReturnStatementRefinementRule {
 			context.setType(Symbol.RETURN, argumentType);
 		}
 
-
 		return new VoidType();
 	}
 

--- a/test/semantic-model/type/type-variable.spec.js
+++ b/test/semantic-model/type/type-variable.spec.js
@@ -3,12 +3,12 @@ import {TypeVariable} from "../../../lib/semantic-model/types/index";
 
 describe("TypeVariable", function () {
 	describe("fresh", function () {
-		it("returns the same instance", function () {
+		it("returns a new instance", function () {
 			// arrange
 			const original = new TypeVariable();
 
 			// act, assert
-			expect(original.fresh()).to.equal(original);
+			expect(original.fresh()).not.to.equal(original);
 		});
 	});
 

--- a/test/type-inference/refinment-rules/binary-expression-refinement-rule.spec.js
+++ b/test/type-inference/refinment-rules/binary-expression-refinement-rule.spec.js
@@ -64,7 +64,7 @@ describe("BinaryExpressionRefinementRule", function () {
 			const refined = rule.refine(addExpression, context);
 
 			// assert
-			sinon.assert.calledWithExactly(BINARY_OPERATORS["+"].refine, nullType, numberType, sinon.match.func);
+			sinon.assert.calledWithExactly(BINARY_OPERATORS["+"].refine, sinon.match.instanceOf(NullType), sinon.match.instanceOf(NumberType), sinon.match.func);
 			expect(refined).to.be.instanceOf(NumberType);
 		});
 	});


### PR DESCRIPTION
This recursion detection tries to figure out if a previous call
used exactly the same arguments. If this is the case, then it can
be expected that both calls will have the same return type. So instead
of evaluating the function again, use the same type variable as return
type as the previous call does. If the previous call completes, then
the return type is substituted.