### PR TITLE
Ignore empty statements in CFG

### DIFF
--- a/lib/cfg/cfg-builder.js
+++ b/lib/cfg/cfg-builder.js
@@ -133,8 +133,8 @@ export class CfgBuilder {
 	//------------------------------------------
 	// Statements
 	//------------------------------------------
-	enterEmptyStatement(path) {
-		this._connectWithSuccessor(path);
+	enterEmptyStatement() {
+		// skip
 	}
 
 	enterBlockStatement (path) {

--- a/lib/cfg/successor.js
+++ b/lib/cfg/successor.js
@@ -123,9 +123,12 @@ export function computeSuccessor (path) {
 
 	// for all other statements, the successor is the following sibling node
 	let sibling = path.getSibling(path.key + 1);
+	while (sibling && sibling.isEmptyStatement()) {
+		sibling = sibling.getSibling(sibling.key + 1);
+	}
 
 	// If the node has no following sibling node, then we reached the end and need to continue on the upper level
-	if (!sibling.node) {
+	if (!sibling.node || sibling.isEmptyStatement()) {
 		return computeSuccessor(path.parentPath);
 	}
 

--- a/test/cfg/cfg-builder.spec.js
+++ b/test/cfg/cfg-builder.spec.js
@@ -37,12 +37,15 @@ describe("CfgBuilder", function () {
 	});
 
 	describe("EmptyStatement", function () {
-		it("creates an edge to the successor node", () => {
-			const {ast, cfg} = toCfg(";");
+		it("skips an empty statement", () => {
+			const {ast, cfg} = toCfg("let x = 10;;x++");
 
 			// assert
-			const emptyStatement = ast.program.body[0];
-			expect(cfg.isConnected(emptyStatement, null, BRANCHES.UNCONDITIONAL)).to.be.true;
+			const declaration = ast.program.body[0];
+			const emptyStatement = ast.program.body[1];
+			const update = ast.program.body[2];
+			expect(cfg.getNode(emptyStatement)).to.be.undefined;
+			expect(cfg.isConnected(declaration, update, BRANCHES.UNCONDITIONAL)).to.be.true;
 		});
 	});
 


### PR DESCRIPTION
Do not include empty statements in the CFG as they have no effect on the
flow or semantic.