### PR TITLE
Hoist function declarations to the body of their scope

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,8 +6,8 @@ import chalk from "chalk";
 import Configuration from "./configuration";
 import Context from "./context";
 import {infer} from "./infer";
-import {TypeInferenceError} from "./type-inference/type-inference-error";
 import {Program} from "./semantic-model/program";
+import {TypeEnvironment} from "./type-inference/type-environment";
 import {plotControlFlowGraph} from "./cfg/dot";
 
 /* eslint-disable no-console */
@@ -45,16 +45,16 @@ try {
 	}
 
 	const exitNode = sourceFile.ast.cfg.getNode(null);
-	const typeEnvironment = exitNode.annotation.in;
+	const typeEnvironment = exitNode && exitNode.annotation ? exitNode.annotation.in : TypeEnvironment.EMPTY;
 
 	console.log("Final type environment in exit node:");
 	typeEnvironment.dump(process.stdout);
-	
+
 	console.log(chalk.green("Final memory usage:", process.memoryUsage().rss / 1024 / 1024));
 	console.log(chalk.green("Success"));
 } catch (error) {
 	let message;
-	if (error instanceof TypeInferenceError && error.node.loc) {
+	if (error.node && error.node.loc) {
 		const sourceFile = program.getSourceFile(error.node.loc.filename);
 		message = chalk.red("Type inference failed for node ") + "\n" + sourceFile.codeFrame(error.node);
 	} else {

--- a/lib/semantic-model/scope.js
+++ b/lib/semantic-model/scope.js
@@ -27,6 +27,19 @@ export class Scope {
 	}
 
 	/**
+	 * Replaces the symbol thiz with that
+	 * @param {Symbol} thiz the symbol to replace
+	 * @param {Symbol} that the symbol that replaces the thiz symbol
+     */
+	replaceSymbol(thiz, that) {
+		assert(that, "that cannot be undefined", "!!");
+		assert(this._symbols.has(thiz.name), "Can only replaces symbol contained in this scope", "symbols.has(thiz.name)");
+		assert(thiz.name === that.name, "The name of the symbols need to be equal", "===");
+
+		this._symbols.set(that.name, that);
+	}
+
+	/**
 	 * Tests if this scope contains a symbol with the given name.
 	 * @param {string} name the name of the symbol
 	 * @returns {boolean} true if this scope contains a symbol with the given name

--- a/lib/semantic-model/symbol-extractor.js
+++ b/lib/semantic-model/symbol-extractor.js
@@ -1,5 +1,12 @@
-import assert from "assert";
 import Symbol, {SymbolFlags} from "./symbol";
+
+class SymbolExtractionError extends Error {
+	constructor(reason, node) {
+		super(reason);
+
+		this.node = node;
+	}
+}
 
 /**
  * AST-Visitor that builds up the symbol table by traversing the AST.
@@ -107,8 +114,9 @@ export class SymbolExtractor {
 	 */
 	enterFunctionDeclaration(path) {
 		let symbol;
+
 		if (path.node.id) {
-			symbol = this._declareIdentifierInScope(path.get("id").node, SymbolFlags.Function);
+			symbol = this._declareIdentifierInScope(path.get("id").node, SymbolFlags.Function | SymbolFlags.Hoisted);
 			symbol.declaration = symbol.valueDeclaration = path.node;
 		} else {
 			symbol = new Symbol("anonymous()", SymbolFlags.Function);
@@ -163,6 +171,7 @@ export class SymbolExtractor {
 		}
 
 		this.program.symbolTable.setSymbol(path.node, thiz);
+		thiz.reference(path.node);
 		return thiz;
 	}
 
@@ -196,6 +205,7 @@ export class SymbolExtractor {
 			object = new Symbol("anonymous object", SymbolFlags.Anonymous);
 		}
 
+		object.reference(path.node);
 		this.program.symbolTable.setSymbol(path.node, object);
 	}
 
@@ -247,7 +257,7 @@ export class SymbolExtractor {
 			assignee.declaration = assignee.declaration || path.node.right;
 		} else {
 			/* istanbul ignore next */
-			assert.fail(`Unsupported left hand side of assignment ${path.node.left.type}.`);
+			throw new SymbolExtractionError(`Unsupported left hand side of assignment ${path.node.left.type}.`, path.node);
 		}
 
 		assignee.valueDeclaration = assignee.valueDeclaration || path.node;
@@ -318,8 +328,7 @@ export class SymbolExtractor {
 	enterIdentifier() {}
 
 	defaultHandler(path) {
-		/* istanbul ignore next */
-		assert.fail(`Unsupported node type for symbol extraction '${path.node.type}.`);
+		throw new SymbolExtractionError(`Unsupported node type for symbol extraction '${path.node.type}.`, path.node);
 	}
 
 	/**
@@ -348,11 +357,30 @@ export class SymbolExtractor {
 		} else {
 			symbol = new Symbol(identifierNode.name, flags);
 			this.scope.addSymbol(symbol);
+
+			if ((flags & SymbolFlags.Hoisted) === SymbolFlags.Hoisted) {
+				this._resolveUnresolvedSymbols(symbol);
+			}
 		}
 
 		this.program.symbolTable.setSymbol(identifierNode, symbol);
 
 		return symbol;
+	}
+
+	_resolveUnresolvedSymbols(resolvedSymbol, scope = this.scope) {
+		const potentiallyUnresolved = scope.getOwnSymbol(resolvedSymbol.name);
+
+		if (potentiallyUnresolved && potentiallyUnresolved.unresolved) {
+			for (const reference of potentiallyUnresolved.references) {
+				this.program.symbolTable.setSymbol(reference, resolvedSymbol);
+				scope.replaceSymbol(potentiallyUnresolved, resolvedSymbol);
+			}
+		}
+
+		for (const childScope of scope._children) {
+			this._resolveUnresolvedSymbols(resolvedSymbol, childScope);
+		}
 	}
 
 	_resolveIdentifiers(...paths) {
@@ -366,10 +394,12 @@ export class SymbolExtractor {
 			symbol = this.scope.resolveSymbol(identifierNode.name);
 		} else {
 			symbol = new Symbol(identifierNode.name, flags);
+			symbol.unresolved = true;
 			this.scope.addSymbol(symbol);
 		}
 
 		this.program.symbolTable.setSymbol(identifierNode, symbol);
+		symbol.reference(identifierNode);
 
 		return symbol;
 	}
@@ -382,9 +412,7 @@ export class SymbolExtractor {
 			object = this._resolveMember(memberPath.get("object"));
 		} else if (memberPath.get("object").isThisExpression()) {
 			object = this.enterThisExpression(memberPath.get("object"));
-		}
-
-		else { // e.g. "test".length, call({});
+		} else { // e.g. "test".length, call({});
 			object = new Symbol("anonymous", SymbolFlags.Anonymous);
 			this.program.symbolTable.setSymbol(memberPath.node.object, object);
 		}
@@ -408,6 +436,7 @@ export class SymbolExtractor {
 		// this.program.symbolTable.setSymbol(memberPath.node, member);
 		this.program.symbolTable.setSymbol(memberPath.node.property, member);
 		this.program.symbolTable.setSymbol(memberPath.node.object, object);
+		member.reference(memberPath.node.property);
 
 		return member;
 	}

--- a/lib/semantic-model/symbol.js
+++ b/lib/semantic-model/symbol.js
@@ -36,6 +36,12 @@ export class Symbol {
 		 * @type {AstNode}
          */
 		this.valueDeclaration = null;
+
+		/**
+		 * Array with nodes referencing this symbol
+		 * @type {Set<AstNode>}
+         */
+		this.references = new Set();
 	}
 
 	/**
@@ -76,6 +82,10 @@ export class Symbol {
 	toString() {
 		return this.name;
 	}
+
+	reference(node) {
+		this.references.add(node);
+	}
 }
 
 
@@ -89,6 +99,7 @@ export const SymbolFlags = {
 	Return:                 0x00000020, // Return statements,
 	Computed:               0x00000030,
 	Anonymous:              0x00000040,
+	Hoisted:                0x00000050,
 	UNKNOWN:                0xffffffff
 };
 

--- a/lib/type-inference/forward-type-inference-analysis.js
+++ b/lib/type-inference/forward-type-inference-analysis.js
@@ -1,9 +1,13 @@
+import traverse from "babel-traverse";
+
 import TypeEnvironment from "./type-environment";
 import {HindleyMilner} from "./hindley-milner";
 import {HindleyMilnerContext} from "./hindley-milner-context";
 import {HindleyMilnerDataFlowAnalysis} from "./hindley-milner-data-flow-analysis";
 import {TypeInferenceContext} from "./type-inference-context";
 import {addsTypesOfBuiltInVariables} from "../semantic-model/built-in-variables";
+import {createTraverseVisitorWrapper} from "../util";
+import {FunctionDeclarationVisitor} from "./function-declaration-visitor";
 
 /**
  * Interface for a type inference analysis
@@ -44,11 +48,18 @@ export class ForwardTypeInferenceAnalysis {
 	analyseSourceFile(sourceFile, typeEnvironment=this.getDefaultTypeEnvironment()) {
 		const cfg = sourceFile.ast.cfg;
 
-		const workListAnalyser = new HindleyMilnerDataFlowAnalysis(this, typeEnvironment);
-		workListAnalyser.analyse(cfg, sourceFile.ast.program.body[0]);
+		const functionDeclarationVisitor = new FunctionDeclarationVisitor(this._program, typeEnvironment);
+		traverse(sourceFile.ast.program, createTraverseVisitorWrapper(functionDeclarationVisitor));
+		typeEnvironment = functionDeclarationVisitor.typeEnvironment;
 
-		const exitNode = cfg.getNode(null);
-		return exitNode ? exitNode.annotation.out : typeEnvironment;
+		const workListAnalyser = new HindleyMilnerDataFlowAnalysis(this, typeEnvironment);
+		const nonEmptyNodes = sourceFile.ast.program.body.filter(node => node.type !== "EmptyStatement");
+		if (nonEmptyNodes.length) {
+			workListAnalyser.analyse(cfg, nonEmptyNodes[0]);
+			return cfg.getNode(null).annotation.out;
+		}
+
+		return typeEnvironment;
 	}
 
 	/**
@@ -64,7 +75,7 @@ export class ForwardTypeInferenceAnalysis {
 		workListAnalyser.analyse(cfg, node);
 
 		const exitNode = cfg.getNode(null);
-		return exitNode ? exitNode.annotation.out : typeEnvironment;
+		return exitNode && exitNode.annotation ? exitNode.annotation.out : typeEnvironment;
 	}
 
 	/**

--- a/lib/type-inference/function-declaration-visitor.js
+++ b/lib/type-inference/function-declaration-visitor.js
@@ -1,0 +1,24 @@
+import {FunctionRefinementRule} from "./refinement-rules/function-refinement-rule";
+import {TypeInferenceContext} from "./type-inference-context";
+/**
+ * Visitor that infers the base type for all functions.
+ * Functions are hoisted therefore need to be defined before it's node is visited
+ */
+export class FunctionDeclarationVisitor {
+
+	constructor(program, typeEnvironment) {
+		this.program = program;
+		this.typeEnvironment = typeEnvironment;
+	}
+
+	enterFunctionDeclaration(path) {
+		const context = new TypeInferenceContext(this.program, this.typeEnvironment);
+		FunctionRefinementRule.inferFunctionType(path.node, context);
+
+		this.typeEnvironment = context.typeEnvironment;
+	}
+
+	defaultHandler() {
+		// OK
+	}
+}

--- a/lib/type-inference/refinement-rules/binary-operators.js
+++ b/lib/type-inference/refinement-rules/binary-operators.js
@@ -139,7 +139,10 @@ export const BINARY_OPERATORS = {
 	"-": new NumberOperator("-"),
 	"*": new NumberOperator("*"),
 	"/": new NumberOperator("/"),
-	"<": new NumberOperator("<"), // TODO support value of
+	"<": new NumberOperator("<"),
+	">": new NumberOperator(">"),
+	"<=": new NumberOperator("<="),
+	">=": new NumberOperator(">="),
 	"==": new ParameterIndependentBinaryOperator("==", BooleanType.create()),
 	"!=": new ParameterIndependentBinaryOperator("==", BooleanType.create()),
 	"===": new StrictEqualityOperator("==="),

--- a/lib/type-inference/refinement-rules/function-refinement-rule.js
+++ b/lib/type-inference/refinement-rules/function-refinement-rule.js
@@ -13,21 +13,24 @@ export class FunctionRefinementRule {
 	}
 
 	refine(node, context) {
-		const parameterTypes = this._getParameterTypes(node);
-		const returnType = this._getReturnType(node, context);
-		const type = new FunctionType(TypeVariable.create(), parameterTypes, returnType, node);
+		let type;
+		// The Type of function declarations is extracted before the worklist algorithm as these are hoisted.
+		if (node.type === "FunctionDeclaration") {
+			type = context.getType(context.getSymbol(node));
+		} else {
+			type = FunctionRefinementRule.inferFunctionType(node, context);
+		}
 
-		context.setType(context.getSymbol(node), type);
 		type.typeEnvironment = context.typeEnvironment; // the type needs to contain it's own declaration
 
 		return type;
 	}
 
-	_getParameterTypes(node) {
+	static _getParameterTypes(node) {
 		return node.params.map(() => TypeVariable.create());
 	}
 
-	_getReturnType(node, context) {
+	static _getReturnType(node, context) {
 		if (this._allNonExceptionExitsWithExplicitReturnStatement(node.body, context)) {
 			return TypeVariable.create();
 		}
@@ -35,10 +38,10 @@ export class FunctionRefinementRule {
 		return VoidType.create();
 	}
 
-	_allNonExceptionExitsWithExplicitReturnStatement(node, context) {
+	static _allNonExceptionExitsWithExplicitReturnStatement(node, context) {
 		const cfg = context.getCfg(node);
 		const cfgNode = cfg.getNode(node);
-		const exitEdges = cfg.getExitEdges(cfgNode);
+		const exitEdges = Array.from(cfg.getExitEdges(cfgNode));
 
 		for (const exitEdge of exitEdges) {
 			if (!t.isReturnStatement(exitEdge.src.value) && exitEdge.branch !== BRANCHES.EXCEPTION) {
@@ -46,7 +49,17 @@ export class FunctionRefinementRule {
 			}
 		}
 
-		return true;
+		return exitEdges.length > 0;
+	}
+
+	static inferFunctionType(node, context) {
+		const parameterTypes = this._getParameterTypes(node);
+		const returnType = this._getReturnType(node, context);
+		const type = new FunctionType(TypeVariable.create(), parameterTypes, returnType, node);
+
+		context.setType(context.getSymbol(node), type);
+
+		return type;
 	}
 }
 

--- a/lib/type-inference/refinement-rules/sequence-expression-refinement-rule.js
+++ b/lib/type-inference/refinement-rules/sequence-expression-refinement-rule.js
@@ -1,0 +1,23 @@
+import {VoidType} from "../../semantic-model/types";
+
+/**
+ * Refinement Rule for sequence expressions like x, a
+ * @implements {RefinementRule}
+ */
+export class SequenceExpressionRefinementRule {
+	canRefine(node) {
+		return node.type === "SequenceExpression";
+	}
+
+	refine(node, context) {
+		let type = VoidType.create();
+
+		for (const expression of node.expressions) {
+			type = context.infer(expression);
+		}
+
+		return type;
+	}
+}
+
+export default SequenceExpressionRefinementRule;

--- a/lib/type-inference/type-environment.js
+++ b/lib/type-inference/type-environment.js
@@ -182,7 +182,8 @@ export class TypeEnvironment {
 	 * @param {WriteStream} stream the target stream
 	 */
 	dump(stream) {
-		this.mappings.forEach((type, symbol) => {
+		const sortedMappings = this.mappings.sortBy((value, key) => key);
+		sortedMappings.forEach((type, symbol) => {
 			stream.write(`${symbol.name} -> ${type}\n`);
 		});
 	}

--- a/test/type-inference/refinment-rules/binary-operators.spec.js
+++ b/test/type-inference/refinment-rules/binary-operators.spec.js
@@ -11,7 +11,7 @@ describe("BinaryOperators", function () {
 		unify.returnsArg(0);
 	});
 
-	for (const numberOperator of ["+", "-", "*", "/", "<<", ">>", ">>>", "%", "|", "^", "&"]) {
+	for (const numberOperator of ["+", "-", "*", "/", "<<", ">>", ">>>", "%", "|", "^", "&", "<", ">", "<=", ">="]) {
 		describe(numberOperator, function () {
 
 			beforeEach(function () {


### PR DESCRIPTION
Function declarations need to be hoisted to the start of the function or program. 

This requires that symbols to functions defined later in the file need to be replaced as soon as a function with the same identifier is "hoisted" in this or a parent scope. 

Additionally the type for function declarations needs to be pre processed. Otherwise a identifier is not defined exception is thrown